### PR TITLE
Implement bidirectional node button

### DIFF
--- a/src/components/FloorEditor.css
+++ b/src/components/FloorEditor.css
@@ -72,6 +72,48 @@
   color: #ffffff;
 }
 
+/* Bidirectional button states */
+.tool-button.bidirectional-button.needs-fixing {
+  border-color: #f59e0b;
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.tool-button.bidirectional-button.needs-fixing:hover {
+  border-color: #d97706;
+  background-color: #fcd34d;
+  color: #92400e;
+}
+
+.tool-button.bidirectional-button.fixed {
+  border-color: #10b981;
+  background-color: #d1fae5;
+  color: #065f46;
+}
+
+.tool-button.bidirectional-button.fixed:hover {
+  border-color: #059669;
+  background-color: #a7f3d0;
+  color: #065f46;
+}
+
+.tool-button.bidirectional-button.neutral {
+  border-color: #6b7280;
+  background-color: #f9fafb;
+  color: #374151;
+}
+
+.tool-button.bidirectional-button.neutral:hover {
+  border-color: #4b5563;
+  background-color: #f3f4f6;
+  color: #374151;
+}
+
+.tool-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .tool-icon {
   font-size: 18px;
   margin-bottom: 4px;

--- a/src/components/FloorEditor/DrawingToolbar.tsx
+++ b/src/components/FloorEditor/DrawingToolbar.tsx
@@ -19,6 +19,11 @@ interface DrawingToolbarProps {
   nodesCount: number;
   selectedNodeForConnection: number | null;
   lastPlacedNodeId: number | null;
+  // Bidirectional button state
+  isBidirectionalFixed: boolean;
+  hasNewNodesAdded: boolean;
+  onFixBidirectional: () => void;
+  isFixingBidirectional: boolean;
 }
 
 const DrawingToolbar: React.FC<DrawingToolbarProps> = ({
@@ -30,7 +35,11 @@ const DrawingToolbar: React.FC<DrawingToolbarProps> = ({
   onClearAll,
   nodesCount,
   selectedNodeForConnection,
-  lastPlacedNodeId
+  lastPlacedNodeId,
+  isBidirectionalFixed,
+  hasNewNodesAdded,
+  onFixBidirectional,
+  isFixingBidirectional
 }) => {
   logger.debug('DrawingToolbar rendered', { activeTool, isDrawingPolygon, pendingPolygonPoints });
 
@@ -102,6 +111,31 @@ const DrawingToolbar: React.FC<DrawingToolbarProps> = ({
             Cancel Drawing
           </Button>
         )}
+        
+        {/* Bidirectional Connections Button */}
+        {nodesCount > 0 && (
+          <button
+            className={`tool-button bidirectional-button ${
+              hasNewNodesAdded && !isBidirectionalFixed ? 'needs-fixing' : 
+              isBidirectionalFixed ? 'fixed' : 'neutral'
+            }`}
+            onClick={onFixBidirectional}
+            disabled={isFixingBidirectional}
+            title={
+              hasNewNodesAdded && !isBidirectionalFixed 
+                ? 'Fix bidirectional connections (new nodes added)'
+                : isBidirectionalFixed 
+                ? 'Connections are bidirectional'
+                : 'Make all connections bidirectional'
+            }
+          >
+            <span className="tool-icon">
+              {isFixingBidirectional ? '⏳' : hasNewNodesAdded && !isBidirectionalFixed ? '⚠️' : '✅'}
+            </span>
+            {isFixingBidirectional ? 'Fixing...' : 'Fix Bidirectional'}
+          </button>
+        )}
+        
         <Button variant="DANGER" onClick={onClearAll}>
           {UI_MESSAGES.FLOOR_EDITOR_CLEAR_ALL}
         </Button>

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -49,6 +49,7 @@ export const API_ENDPOINTS = {
   ROUTE_NODES: '/api/RouteNode',
   ROUTE_NODE_BY_ID: (id: string | number) => `/api/RouteNode/${id}`,
   ROUTE_NODES_BY_FLOOR: (floorId: string | number) => `/api/RouteNode?floor=${floorId}`,
+  ROUTE_NODES_FIX_BIDIRECTIONAL: '/api/RouteNode/fixBidirectionalConnections',
   // ROUTE_NODES_BY_TYPE: (nodeType: string) => `/api/RouteNode/type/${nodeType}`,
 } as const;
 

--- a/src/utils/api_helpers/routeNodesApi.ts
+++ b/src/utils/api_helpers/routeNodesApi.ts
@@ -2,12 +2,26 @@
 import {FloorScopedApi} from "../abstract_classes/floorScopedApi";
 import {API_ENDPOINTS} from "../../constants/api";
 import {RouteNode} from "../../interfaces/RouteNode";
+import {logger} from "../api";
+import {apiRequest} from "./apiRequest";
 
 export class RouteNodesApi extends FloorScopedApi<RouteNode> {
     resourceEndpoint = API_ENDPOINTS.ROUTE_NODES;
 
     getByFloorEndpoint(floorId: number): string {
         return API_ENDPOINTS.ROUTE_NODES_BY_FLOOR(floorId);
+    }
+
+    // Fix bidirectional connections for all nodes on a floor
+    async fixBidirectionalConnections(floorId: number): Promise<void> {
+        logger.info('Fixing bidirectional connections for floor', { floorId });
+        
+        await apiRequest<void>(API_ENDPOINTS.ROUTE_NODES_FIX_BIDIRECTIONAL, {
+            method: 'POST',
+            body: JSON.stringify({ floorId }),
+        });
+        
+        logger.info('Successfully fixed bidirectional connections for floor', { floorId });
     }
 
     // getByType(nodeType: string): Promise<RouteNode[]> {


### PR DESCRIPTION
Add a button to the Floor Editor toolbar to make all route nodes bidirectional, providing visual feedback on connection status.

This resolves Linear issue SAM-22 by allowing users to trigger an API call to fix bidirectional connections for all nodes on the current floor. The button changes color (yellow for "needs fixing", green for "fixed") and displays a loading state, enhancing user experience and ensuring data consistency.

---
Linear Issue: [SAM-22](https://linear.app/samishuraim/issue/SAM-22/button-to-make-all-node-bidirectional)

<a href="https://cursor.com/background-agent?bcId=bc-16d27032-9b0c-4ad3-aa2e-a3a8d6576526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-16d27032-9b0c-4ad3-aa2e-a3a8d6576526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

