### PR TITLE
Add calculate nearest node button

### DIFF
--- a/src/components/FloorEditor.css
+++ b/src/components/FloorEditor.css
@@ -6,6 +6,112 @@
   gap: 16px;
 }
 
+/* Actions Section */
+.actions-section {
+  padding: 16px;
+  background-color: #f1f5f9;
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  margin-bottom: 8px;
+}
+
+.actions-title {
+  margin: 0 0 12px 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #334155;
+}
+
+.actions-buttons {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.action-button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background-color: #ffffff;
+  border: 2px solid #e2e8f0;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 14px;
+  font-weight: 500;
+  color: #64748b;
+  min-height: 44px;
+}
+
+.action-button:hover {
+  border-color: #3b82f6;
+  background-color: #f1f5f9;
+  color: #3b82f6;
+}
+
+.action-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.action-icon {
+  font-size: 16px;
+}
+
+.action-text {
+  font-weight: 500;
+}
+
+/* Action button specific states */
+.action-button.bidirectional-button.needs-fixing {
+  border-color: #f59e0b;
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.action-button.bidirectional-button.needs-fixing:hover {
+  border-color: #d97706;
+  background-color: #fcd34d;
+  color: #92400e;
+}
+
+.action-button.bidirectional-button.fixed {
+  border-color: #10b981;
+  background-color: #d1fae5;
+  color: #065f46;
+}
+
+.action-button.bidirectional-button.fixed:hover {
+  border-color: #059669;
+  background-color: #a7f3d0;
+  color: #065f46;
+}
+
+.action-button.bidirectional-button.neutral {
+  border-color: #6b7280;
+  background-color: #f9fafb;
+  color: #374151;
+}
+
+.action-button.bidirectional-button.neutral:hover {
+  border-color: #4b5563;
+  background-color: #f3f4f6;
+  color: #374151;
+}
+
+.action-button.recalculate-button {
+  border-color: #8b5cf6;
+  background-color: #f3e8ff;
+  color: #6b21a8;
+}
+
+.action-button.recalculate-button:hover {
+  border-color: #7c3aed;
+  background-color: #ede9fe;
+  color: #6b21a8;
+}
+
 .floor-editor-error {
   padding: 16px;
   background-color: #fee2e2;

--- a/src/components/FloorEditor/ActionsSection.tsx
+++ b/src/components/FloorEditor/ActionsSection.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import {createLogger} from '../../utils/logger';
+
+const logger = createLogger('ActionsSection');
+
+interface ActionsSectionProps {
+  // Bidirectional button props
+  nodesCount: number;
+  isBidirectionalFixed: boolean;
+  hasNewNodesAdded: boolean;
+  onFixBidirectional: () => void;
+  isFixingBidirectional: boolean;
+  
+  // POI recalculate button props
+  floorId: number;
+  onRecalculatePoiNodes: () => void;
+  isRecalculatingPoiNodes: boolean;
+}
+
+const ActionsSection: React.FC<ActionsSectionProps> = ({
+  nodesCount,
+  isBidirectionalFixed,
+  hasNewNodesAdded,
+  onFixBidirectional,
+  isFixingBidirectional,
+  floorId,
+  onRecalculatePoiNodes,
+  isRecalculatingPoiNodes
+}) => {
+  logger.debug('ActionsSection rendered', { 
+    nodesCount, 
+    isBidirectionalFixed, 
+    hasNewNodesAdded, 
+    floorId 
+  });
+
+  return (
+    <div className="actions-section">
+      <h3 className="actions-title">Actions</h3>
+      <div className="actions-buttons">
+        {/* Bidirectional Connections Button */}
+        {nodesCount > 0 && (
+          <button
+            className={`action-button bidirectional-button ${
+              hasNewNodesAdded && !isBidirectionalFixed ? 'needs-fixing' : 
+              isBidirectionalFixed ? 'fixed' : 'neutral'
+            }`}
+            onClick={onFixBidirectional}
+            disabled={isFixingBidirectional}
+            title={
+              hasNewNodesAdded && !isBidirectionalFixed 
+                ? 'Fix bidirectional connections (new nodes added)'
+                : isBidirectionalFixed 
+                ? 'Connections are bidirectional'
+                : 'Make all connections bidirectional'
+            }
+          >
+            <span className="action-icon">
+              {isFixingBidirectional ? '⏳' : hasNewNodesAdded && !isBidirectionalFixed ? '⚠️' : '✅'}
+            </span>
+            <span className="action-text">
+              {isFixingBidirectional ? 'Fixing...' : 'Fix Bidirectional'}
+            </span>
+          </button>
+        )}
+
+        {/* Calculate Nearest Nodes for POIs Button */}
+        <button
+          className="action-button recalculate-button"
+          onClick={onRecalculatePoiNodes}
+          disabled={isRecalculatingPoiNodes}
+          title="Recalculate closest nodes for all POIs on this floor"
+        >
+          <span className="action-icon">
+            {isRecalculatingPoiNodes ? '⏳' : '🎯'}
+          </span>
+          <span className="action-text">
+            {isRecalculatingPoiNodes ? 'Calculating...' : 'Calculate POI Nodes'}
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ActionsSection;

--- a/src/components/FloorEditor/DrawingToolbar.tsx
+++ b/src/components/FloorEditor/DrawingToolbar.tsx
@@ -19,11 +19,6 @@ interface DrawingToolbarProps {
   nodesCount: number;
   selectedNodeForConnection: number | null;
   lastPlacedNodeId: number | null;
-  // Bidirectional button state
-  isBidirectionalFixed: boolean;
-  hasNewNodesAdded: boolean;
-  onFixBidirectional: () => void;
-  isFixingBidirectional: boolean;
 }
 
 const DrawingToolbar: React.FC<DrawingToolbarProps> = ({
@@ -35,11 +30,7 @@ const DrawingToolbar: React.FC<DrawingToolbarProps> = ({
   onClearAll,
   nodesCount,
   selectedNodeForConnection,
-  lastPlacedNodeId,
-  isBidirectionalFixed,
-  hasNewNodesAdded,
-  onFixBidirectional,
-  isFixingBidirectional
+  lastPlacedNodeId
 }) => {
   logger.debug('DrawingToolbar rendered', { activeTool, isDrawingPolygon, pendingPolygonPoints });
 
@@ -110,30 +101,6 @@ const DrawingToolbar: React.FC<DrawingToolbarProps> = ({
           <Button variant="SECONDARY" onClick={onCancelDrawing}>
             Cancel Drawing
           </Button>
-        )}
-        
-        {/* Bidirectional Connections Button */}
-        {nodesCount > 0 && (
-          <button
-            className={`tool-button bidirectional-button ${
-              hasNewNodesAdded && !isBidirectionalFixed ? 'needs-fixing' : 
-              isBidirectionalFixed ? 'fixed' : 'neutral'
-            }`}
-            onClick={onFixBidirectional}
-            disabled={isFixingBidirectional}
-            title={
-              hasNewNodesAdded && !isBidirectionalFixed 
-                ? 'Fix bidirectional connections (new nodes added)'
-                : isBidirectionalFixed 
-                ? 'Connections are bidirectional'
-                : 'Make all connections bidirectional'
-            }
-          >
-            <span className="tool-icon">
-              {isFixingBidirectional ? '⏳' : hasNewNodesAdded && !isBidirectionalFixed ? '⚠️' : '✅'}
-            </span>
-            {isFixingBidirectional ? 'Fixing...' : 'Fix Bidirectional'}
-          </button>
         )}
         
         <Button variant="DANGER" onClick={onClearAll}>

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -39,6 +39,7 @@ export const API_ENDPOINTS = {
   POIS: '/api/Poi',
   POI_BY_ID: (id: string | number) => `/api/Poi/${id}`,
   POIS_BY_FLOOR: (floorId: string | number) => `/api/Poi?floor=${floorId}`,
+  POIS_RECALCULATE_CLOSEST_NODES: '/api/Poi/recalculateClosestNodes',
   
   // POI Categories
   POI_CATEGORIES: '/api/PoiCategory',

--- a/src/utils/api_helpers/polygonsApi.ts
+++ b/src/utils/api_helpers/polygonsApi.ts
@@ -1,11 +1,41 @@
 import {FloorScopedApi} from "../abstract_classes/floorScopedApi";
 import {API_ENDPOINTS} from "../../constants/api";
 import {Polygon} from "../../interfaces/Polygon";
+import {apiRequest} from "./apiRequest";
+import {logger} from "../api";
 
 export class PolygonsApi extends FloorScopedApi<Polygon> {
     resourceEndpoint = API_ENDPOINTS.POIS;
 
     getByFloorEndpoint(floorId: number): string {
         return API_ENDPOINTS.POIS_BY_FLOOR(floorId);
+    }
+
+    // Recalculate closest nodes for POIs
+    async recalculateClosestNodes(floorId?: number): Promise<{
+        success: boolean;
+        updatedPois: number;
+        floorId?: number;
+        message: string;
+        report?: any;
+    }> {
+        logger.info('Recalculating closest nodes for POIs', { floorId });
+        
+        const endpoint = floorId 
+            ? `${API_ENDPOINTS.POIS_RECALCULATE_CLOSEST_NODES}?floorId=${floorId}`
+            : API_ENDPOINTS.POIS_RECALCULATE_CLOSEST_NODES;
+        
+        const result = await apiRequest<{
+            success: boolean;
+            updatedPois: number;
+            floorId?: number;
+            message: string;
+            report?: any;
+        }>(endpoint, {
+            method: 'POST',
+        });
+        
+        logger.info('Successfully recalculated closest nodes for POIs', { floorId, result });
+        return result;
     }
 }


### PR DESCRIPTION
Add a 'Calculate POI Nodes' button and an 'Actions' section to the Floor Editor to allow users to trigger POI closest node recalculation and organize action buttons.

---
Linear Issue: [SAM-24](https://linear.app/samishuraim/issue/SAM-24/create-calculate-nearest-node-to-poi-button)

<a href="https://cursor.com/background-agent?bcId=bc-6f028f92-c232-4c84-b6cd-f81cc261e50c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6f028f92-c232-4c84-b6cd-f81cc261e50c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

